### PR TITLE
Bump supported version to 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.30", "3.32", "3.34", "3.36", "3.38", "40"],
+	"shell-version": ["3.30", "3.32", "3.34", "3.36", "3.38", "40", "41"],
 	"uuid": "workspace-switch-wraparound@theychx.org",
 	"name": "Workspace Switch Wraparound",
 	"description": "When switching workspaces, going down from the bottom workspace switches to the top workspace. Likewise, up from the top workspace goes to the bottom workspace.",


### PR DESCRIPTION
So that people can actually install from the gnome site from gnome 41. Might be nice to find a way to do this automagically for future gnome versions