### PR TITLE
Adding version 43 on metadata.json

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,8 @@
 		"3.38",
 		"40",
 		"41",
-		"42"
+		"42",
+		"43"
 	],
 	"uuid": "workspace-switch-wraparound@theychx.org",
 	"name": "Workspace Switch Wraparound",


### PR DESCRIPTION
I've tested on my environment using gnome 43 and it's working.