### PR TITLE
Adding version 44 on metadata.json

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,7 +8,8 @@
 		"40",
 		"41",
 		"42",
-		"43"
+		"43",
+		"44"
 	],
 	"uuid": "workspace-switch-wraparound@theychx.org",
 	"name": "Workspace Switch Wraparound",


### PR DESCRIPTION
Tested on Gnome 44 on Ubuntu 23.04, still works flawlessly  