### PR TITLE
Adjust to support gnome 45

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1,4 +1,4 @@
-const Meta = imports.gi.Meta;
+import Meta from 'gi://Meta';
 
 function lastWSIndex() { return global.workspace_manager.n_workspaces - 1 }
 
@@ -28,14 +28,13 @@ function get_neighbor(direction) {
 
 let old = {};
 
-function init() {
-	old = Meta.Workspace.prototype.get_neighbor;
-}
+export default class WorkspaceSwitchWraparound {
+	enable() {
+		old = Meta.Workspace.prototype.get_neighbor;
+		Meta.Workspace.prototype.get_neighbor = get_neighbor;
+	}
 
-function enable() {
-	Meta.Workspace.prototype.get_neighbor = get_neighbor;
-}
-
-function disable() {
-	Meta.Workspace.prototype.get_neighbor = old;
+	disable() {
+		Meta.Workspace.prototype.get_neighbor = old;
+	}
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,7 +9,8 @@
 		"41",
 		"42",
 		"43",
-		"44"
+		"44",
+		"45"
 	],
 	"uuid": "workspace-switch-wraparound@theychx.org",
 	"name": "Workspace Switch Wraparound",


### PR DESCRIPTION
Here are the adjustments to support Gnome 45.
This breaks compatibility with Gnome <= 44 though. I don't know if it's possible to keep compatibility in an elegant way. Parts of the answer are in https://gjs.guide/extensions/development/targeting-older-gnome.html